### PR TITLE
Allow Object as search property

### DIFF
--- a/src/gridjs-vue.vue
+++ b/src/gridjs-vue.vue
@@ -41,7 +41,7 @@ export default {
       default: undefined
     },
     search: {
-      type: Boolean,
+      type: [Object, Boolean],
       default: false
     },
     server: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3741,10 +3741,10 @@ graceful-fs@^4.1.2:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
-gridjs@^3.0.2:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/gridjs/-/gridjs-3.1.0.tgz#f2d4b2ec8a5d88df83a5fd4019c23026f4c2ba76"
-  integrity sha512-QIxWUZ3avjBtE8n/3IPdhowgHI4Tjp5HuhYGU91RF4JQla0LvIVNl6DVSWlSWIsYJkGrC7jpenPjeZZ5ULbpQw==
+gridjs@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/gridjs/-/gridjs-3.2.1.tgz#0b3d240bc6d7f546c71238e6c0c3d2e0af289df8"
+  integrity sha512-2g2doNGj1/6PUUbT2uAyJ8myDUX/BnQDpLBUC5WWXxpZjYGxK9tg4mm+Yp34/WiUCIjQHWq6TEVKjmY8GKWDlA==
   dependencies:
     preact "^10.5.7"
     tslib "^2.0.1"


### PR DESCRIPTION
If we use the server side search functionality, we'd need to pass an object to the search property, like here: https://gridjs.io/docs/examples/server-side-search. 

This PR closes the #61 

I like this project. Keep up the good work!