### PR TITLE
Feature: add height variable to wrapper component

### DIFF
--- a/attributes.json
+++ b/attributes.json
@@ -15,6 +15,10 @@
     "type": ["string", "function"],
     "description": "String of HTML table selector or function returning HTML table string. Default: undefined"
   },
+  "gridjs-vue/height": {
+    "type": "string",
+    "description": "String that sets the height of the table excluding search, pagination, etc. Default: undefined"
+  },
   "gridjs-vue/language": {
     "type": "object",
     "description": "Localization dictionary object. Default: undefined"

--- a/src/gridjs-vue.vue
+++ b/src/gridjs-vue.vue
@@ -28,6 +28,10 @@ export default {
       type: [String, Function],
       default: undefined
     },
+    height: {
+      type: [String],
+      default: undefined
+    },
     language: {
       type: Object,
       default: undefined
@@ -87,12 +91,11 @@ export default {
         autoWidth: this.autoWidth,
         columns: this.cols ? this.cols : [this.dict.error.columnsUndefined],
         data: this.rows ? this.rows : this.from || this.server ? undefined : [[this.dict.error.rowsUndefined]],
+        height: this.height,
         pagination: this.pagination,
         sort: this.sort,
         width: this.width
       }
-
-      // let classNames
 
       if (this.classNames) options.className = this.classNames
       if (this.from)
@@ -119,6 +122,9 @@ export default {
       this.update()
     },
     from() {
+      this.update()
+    },
+    height() {
       this.update()
     },
     language() {


### PR DESCRIPTION
Adding a missing parameter that is supported by the upstream core component (see https://gridjs.io/docs/config/height).
Tested with the test component `Test.vue` and works as expected.